### PR TITLE
Change /plugins to show CLX, not RCL

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -19,7 +19,8 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::get('/plugins', [PluginDataController::class, 'allRclMessages']);
+Route::get('/plugins', [PluginDataController::class, 'allClxMessages']);
+Route::get('/plugins-rcl', [PluginDataController::class, 'allRclMessages']);
 
 Route::get('/clx-messages', [PluginDataController::class, 'detailedClxMessages']);
 


### PR DESCRIPTION
After a DM with Erik it's been realised that plugins like UKCP and VATCAN have been using the /plugins endpoint, which shows RCL request data. The problem here is that it will not reflect any changes in the clearance. Providing most clearances will probably be issued as is its not too noticeable, but still not good. Not sure if this is the best way to fix it. Getting plugins to change the endpoint and data to detailedClxMessages is probably not on the cards 24 hours before the event lol 