### PR TITLE
April 2024 RCL changes

### DIFF
--- a/app/Enums/DatalinkAuthorities.php
+++ b/app/Enums/DatalinkAuthorities.php
@@ -14,7 +14,7 @@ enum DatalinkAuthorities: string
     case CZQXD = 'CZQX';
     case CZQMD = 'CZQM';
     case SYS = 'SYST';
-    case OCEN = "OCEN";
+    case OCEN = 'OCEN';
 
     public function description(): string
     {

--- a/app/Enums/DatalinkAuthorities.php
+++ b/app/Enums/DatalinkAuthorities.php
@@ -14,6 +14,7 @@ enum DatalinkAuthorities: string
     case CZQXD = 'CZQX';
     case CZQMD = 'CZQM';
     case SYS = 'SYST';
+    case OCEN = "OCEN";
 
     public function description(): string
     {
@@ -28,6 +29,7 @@ enum DatalinkAuthorities: string
             DatalinkAuthorities::CZQMD => 'Moncton (Domestic)',
             DatalinkAuthorities::CZQXD => 'Gander (Domestic)',
             DatalinkAuthorities::SYS => 'natTrak System',
+            DatalinkAuthorities::OCEN => 'Oceanic Controller',
             default => 'N/A'
         };
     }

--- a/app/Enums/DatalinkAuthorities.php
+++ b/app/Enums/DatalinkAuthorities.php
@@ -13,7 +13,7 @@ enum DatalinkAuthorities: string
     case TTZO = 'TTZO';
     case CZQXD = 'CZQX';
     case CZQMD = 'CZQM';
-    case SYS = 'SYSTEM';
+    case SYS = 'SYST';
 
     public function description(): string
     {

--- a/app/Enums/DatalinkAuthorities.php
+++ b/app/Enums/DatalinkAuthorities.php
@@ -13,6 +13,7 @@ enum DatalinkAuthorities: string
     case TTZO = 'TTZO';
     case CZQXD = 'CZQX';
     case CZQMD = 'CZQM';
+    case SYS = 'SYSTEM';
 
     public function description(): string
     {
@@ -26,6 +27,7 @@ enum DatalinkAuthorities: string
             DatalinkAuthorities::KZNY => 'New York',
             DatalinkAuthorities::CZQMD => 'Moncton (Domestic)',
             DatalinkAuthorities::CZQXD => 'Gander (Domestic)',
+            DatalinkAuthorities::SYS => 'natTrak System',
             default => 'N/A'
         };
     }

--- a/app/Enums/RclResponsesEnum.php
+++ b/app/Enums/RclResponsesEnum.php
@@ -2,7 +2,7 @@
 
 namespace App\Enums;
 
-enum RclErrorsEnum: string
+enum RclResponsesEnum: string
 {
     case TooEarly = "RCL REJECTED\nRCL SENT TOO EARLY";
     case TooLate = "RCL REJECTED\nRCL RECEIVED TOO LATE REVERT TO VOICE PROCEDURES";
@@ -11,6 +11,7 @@ enum RclErrorsEnum: string
     case Cancelled = "RCL/CLA REJECTED\nCLEARANCE CALLED REVERT TO VOICE PROCEDURES";
     case Invalid = "RCL REJECTED\nINVAILD %s\nRESUBMIT YOUR REQUEST";
     case Contact = "RCL/CLA RECEIVED\nCONTACT %s BY VOICE";
+    case Acknowledge = "RCL/CLA RECEIVED\nFLY CURRENT FLIGHT PLAN OR AS AMENDED BY ATC\nCONTINUE TO MONITOR NATTRAK UNTIL ENTERING OCA";
 
     public function text(): string
     {
@@ -21,7 +22,8 @@ enum RclErrorsEnum: string
             self::Negotiation => 'Negotiation of your clearance with the controller is required. Contact the controller specified via voice.',
             self::Cancelled => 'Clearance cancelled by the controller. Revert to voice or check private messages in pilot client.',
             self::Invalid => 'Check the identified error, amend and re-submit. For help contact the controller.',
-            self::Contact => 'Revert to voice.'
+            self::Contact => 'Revert to voice.',
+            self::Acknowledge => 'Request acknowledged. Continue as planned. Monitor natTrak for ATC amendments'
         };
     }
 }

--- a/app/Enums/RclResponsesEnum.php
+++ b/app/Enums/RclResponsesEnum.php
@@ -23,7 +23,7 @@ enum RclResponsesEnum: string
             self::Cancelled => 'Clearance cancelled by the controller. Revert to voice or check private messages in pilot client.',
             self::Invalid => 'Check the identified error, amend and re-submit. For help contact the controller.',
             self::Contact => 'Revert to voice.',
-            self::Acknowledge => 'Request acknowledged. Continue as planned. Monitor natTrak for ATC amendments'
+            self::Acknowledge => 'Request acknowledged. Continue as planned. Monitor natTrak for ATC amendments.'
         };
     }
 }

--- a/app/Http/Controllers/ClxMessagesController.php
+++ b/app/Http/Controllers/ClxMessagesController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Enums\ClxCancellationReasons;
 use App\Enums\DatalinkAuthorities;
-use App\Enums\RclErrorsEnum;
+use App\Enums\RclResponsesEnum;
 use App\Events\ClxIssuedEvent;
 use App\Http\Requests\ClxMessageRequest;
 use App\Models\ClxMessage;
@@ -280,8 +280,8 @@ class ClxMessagesController extends Controller
             author: $datalinkAuthority,
             recipient: $rclMessage->callsign,
             recipientAccount: $rclMessage->vatsimAccount,
-            message: sprintf(RclErrorsEnum::Contact->value, strtoupper($datalinkAuthority->description())),
-            caption: RclErrorsEnum::Contact->text()
+            message: sprintf(RclResponsesEnum::Contact->value, strtoupper($datalinkAuthority->description())),
+            caption: RclResponsesEnum::Contact->text()
         );
 
         flashAlert(type: 'success', title: null, message: 'Revert to voice message sent. You can delete the request now.', toast: true, timer: true);

--- a/app/Http/Controllers/RclMessagesController.php
+++ b/app/Http/Controllers/RclMessagesController.php
@@ -2,19 +2,24 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\DatalinkAuthorities;
+use App\Enums\RclResponsesEnum;
 use App\Http\Requests\RclMessageRequest;
 use App\Models\RclMessage;
 use App\Models\Track;
+use App\Services\CpdlcService;
 use App\Services\VatsimDataService;
 use Illuminate\Support\Facades\Auth;
 
 class RclMessagesController extends Controller
 {
     private $dataService;
+    public CpdlcService $cpdlcService;
 
-    public function __construct(VatsimDataService $vatsimDataService)
+    public function __construct(VatsimDataService $vatsimDataService, CpdlcService $cpdlcService)
     {
         $this->dataService = $vatsimDataService;
+        $this->cpdlcService = $cpdlcService;
     }
 
     public function index()
@@ -52,6 +57,13 @@ class RclMessagesController extends Controller
             }
         }
         $rclMessage->save();
+        $this->cpdlcService->sendMessage(
+            author: DatalinkAuthorities::SYS,
+            recipient: $rclMessage->callsign,
+            recipientAccount: $rclMessage->vatsimAccount,
+            message: sprintf(RclResponsesEnum::Acknowledge->value, strtoupper(DatalinkAuthorities::SYS->description())),
+            caption: RclResponsesEnum::Acknowledge->text()
+        );
 
         return redirect()->route('pilots.message-history');
     }

--- a/app/Http/Requests/RclMessageRequest.php
+++ b/app/Http/Requests/RclMessageRequest.php
@@ -106,8 +106,8 @@ class RclMessageRequest extends FormRequest
         // Calculate the difference in minutes between the current time and entry time
         $minutesDifference = $currentDateTime->diffInMinutes($entryTime);
 
-        // Check if the difference is within the range [15, 45] minutes and not negative (entry time is in the future)
-        if ($minutesDifference >= 14 && $minutesDifference <= 61) {
+        // Check if the difference is within the range [15, 90] minutes and not negative (entry time is in the future)
+        if ($minutesDifference >= 14 && $minutesDifference <= 91) {
             return true;
         }
 
@@ -116,7 +116,7 @@ class RclMessageRequest extends FormRequest
         $minutesToMidnight = $currentDateTime->diffInMinutes($midnight);
         $minutesFromMidnight = $entryTime->diffInMinutes($midnight);
 
-        if ($minutesToMidnight >= 14 && $minutesFromMidnight >= 0 && $minutesFromMidnight <= 61) {
+        if ($minutesToMidnight >= 14 && $minutesFromMidnight >= 0 && $minutesFromMidnight <= 91) {
             return true;
         }
 

--- a/app/Http/Requests/RclMessageRequest.php
+++ b/app/Http/Requests/RclMessageRequest.php
@@ -92,7 +92,7 @@ class RclMessageRequest extends FormRequest
                 if (config('app.rcl_time_constraints_enabled') && strlen($this->entry_time) == 4) {
                     if (!$this->entryTimeWithinRange($this->entry_time)) {
                         $this->cpdlcService->sendMessage(author: DatalinkAuthorities::SYS, recipient: $this->callsign, recipientAccount: Auth::user(), message: sprintf(RclResponsesEnum::Contact->value, strtoupper(DatalinkAuthorities::OCEN->description())), caption: RclResponsesEnum::Contact->text());
-                        $validator->errors()->add('entry_time.range', 'You are either too early or too late to submit oceanic clearance. If you are entering the oceanic more than 45 minutes from now, come back when within 45 minutes. If your entry is within 15 minutes, or you have already entered, request clearance via voice.');
+                        $validator->errors()->add('entry_time.range', 'You are either too early or too late to submit oceanic clearance. If you are entering the oceanic more than 90 minutes from now, come back when within 90 minutes. If your entry is within 15 minutes, or you have already entered, request clearance via voice.');
                     }
                 }
             }

--- a/resources/views/livewire/pilots/message-history.blade.php
+++ b/resources/views/livewire/pilots/message-history.blade.php
@@ -1,8 +1,8 @@
 <div>
     <div class="mb-4">
-            <h5>Clearance Messages</h5>
+            <h5>Controller Messages</h5>
             @if (count($clxMessages) == 0)
-                <div class="fst-italic">No messages. If you haven't received clearance within 10 minutes of requesting, contact the controller.</div>
+                <div class="fst-italic">No messages.</div>
             @endif
             @foreach($clxMessages as $message)
                 <div class="card" wire:key="clx-{{ $message['created_at'] }}">
@@ -39,7 +39,7 @@
             @endforeach
     </div>
     <div class="mb-4">
-        <h5>CPDLC Messages</h5>
+        <h5>Automatic Messages</h5>
         @if (count($cpdlcMessages) == 0)
             <div class="fst-italic">No messages.</div>
         @endif
@@ -65,7 +65,7 @@
         @endforeach
     </div>
     <div class="mb-4">
-        <h5>Request Messages</h5>
+        <h5>Ocenaic Clearance Request Messages</h5>
         @if (count($rclMessages) == 0)
             <div class="fst-italic">No messages. Request clearance via the Request Clearance button on the pilots toolbar.</div>
         @endif

--- a/resources/views/pilots/rcl/create.blade.php
+++ b/resources/views/pilots/rcl/create.blade.php
@@ -27,7 +27,7 @@
         @endif
         <div class="bg-body-secondary py-3 px-3 mb-4 rounded">
             <p>You should request oceanic clearance <span class="fw-bold">30 minutes prior to oceanic entry.</span><br><a href="#" data-bs-toggle="modal" data-bs-target="#airportInfo" class="fst-italic text-muted">At some airports, you must request prior to departure.</a></p>
-            <p>Requests will be rejected if your ETA has past, is under 10 minutes from now, or is over 45 minutes away.</p>
+            <p>Requests will be rejected if your ETA has past, is under 15 minutes from now, or is over 90 minutes away.</p>
             <p class="mb-0">Need help? Check out the <i>Help</i> button in the navigation bar.</p>
         </div>
         @if (config('app.ctp_info_enabled'))


### PR DESCRIPTION

Changes to comply with #125  request.

When an RCL is sent, if it complies with the standard validation rules, a CPDLC message will be automatically sent to continue flying as requested and to monitor for updates. If there is an issue with entry time, a different message will be sent asking them to revert to voice (on top of the validation error on the RCL request page). 

<img width="1365" alt="image" src="https://github.com/vatsimnetwork/nattrak/assets/143304913/a53ede7b-e3ed-406c-b754-1efa24fa4d7d">

Currently the controller logic has not changed (all requests are still "pending"), but pending requests will still show in the conflict checker as previously.