### PR TITLE
QOL for RR input, to expand to right edge

### DIFF
--- a/resources/views/livewire/controllers/create-manual-clx.blade.php
+++ b/resources/views/livewire/controllers/create-manual-clx.blade.php
@@ -93,7 +93,7 @@
                                 <div class="fst-italic">or...</div>
                             </div>
                         </div>
-                        <div class="col-auto">
+                        <div class="col-lg">
                             <div class="form-floating">
                                 <input wire:model.blur="randomRouteing" value="{{ old('random_routeing') }}" type="text" class="form-control" name="random_routeing" id="random_routeing" placeholder="e.g. GOMUP 59/20 59/30 58/40 56/50 JANJO" onblur="this.value = this.value.toUpperCase()">
                                 <label for="random_routeing">Random routeing</label>


### PR DESCRIPTION
change the class attribute for the Random Routeing input box, to have it extended until the page right border, to facilitate visualising the input of the full route
(does not include the modified line 11 to keep changes separate in case rejected)