### PR TITLE
Fix entry time requirements on API

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -39,7 +39,7 @@ class Kernel extends ConsoleKernel
         /**
          * Move auto acknowledged RCL messages from pending to processed after 15 min
          */
-        if (config('services.pruning.prune_messages') && config('app.rcl_auto_acknowledgement_enabled')) {
+        if (config('services.pruning.prune_msgs') && config('app.rcl_auto_acknowledgement_enabled')) {
             $schedule->command('rcl-messages:clear-auto-acknowledged')->hourly();
         }
 

--- a/app/Http/Controllers/Api/PluginDataController.php
+++ b/app/Http/Controllers/Api/PluginDataController.php
@@ -58,7 +58,7 @@ class PluginDataController extends Controller
         );
     }
 
-    public function detailedClxMessages(Request $request)
+    public function     detailedClxMessages(Request $request)
     {
         $trackToSortBy = null;
         $requestAsksForTrack = false;
@@ -99,7 +99,8 @@ class PluginDataController extends Controller
                 ],
                 'entry' => [
                     'fix' => $msg->entry_fix,
-                    'estimate' => self::formatTime($msg->rclMessage->entry_time),
+                    'cto' => $msg->cto_time,
+                    'estimate' => $msg->rclMessage->entry_time,
                     'restriction' => $msg->entry_time_restriction,
                 ],
                 'extra_info' => $msg->free_text,

--- a/app/Http/Controllers/ClxMessagesController.php
+++ b/app/Http/Controllers/ClxMessagesController.php
@@ -145,7 +145,9 @@ class ClxMessagesController extends Controller
          */
         $entryRequirement = null;
         if ($request->filled('entry_time_type') && $request->filled('entry_time_requirement')) {
-            $entryRequirement = "{$request->get('entry_time_type')}{$request->get('entry_time_requirement')}";
+            if ($request->get('entry_time_type') != 'none') {
+                $entryRequirement = "{$request->get('entry_time_type')}{$request->get('entry_time_requirement')}";
+            }
         }
 
         $datalinkAuthority = DatalinkAuthority::find($request->get('datalink_authority'));
@@ -161,6 +163,7 @@ class ClxMessagesController extends Controller
             'mach' => $request->filled('atc_mach') ? $request->get('atc_mach') : $rclMessage->mach,
             'entry_fix' => $newEntryFix ?? $rclMessage->entry_fix,
             'entry_time_restriction' => $entryRequirement ?? null,
+            'cto_time' => $request->filled('cto_time') ? $request->get('cto_time') : $rclMessage->entry_time,
             'raw_entry_time_restriction' => $request->get('entry_time_requirement'),
             'free_text' => $isReclearance ? '** RECLEARANCE '.now()->format('Hi').' ** '.$request->get('free_text') : $request->get('free_text'),
             'datalink_authority_id' => $datalinkAuthority->id,

--- a/app/Http/Requests/ClxMessageRequest.php
+++ b/app/Http/Requests/ClxMessageRequest.php
@@ -16,6 +16,7 @@ class ClxMessageRequest extends FormRequest
             'atc_mach' => 'nullable|numeric|digits:3',
             'free_text' => 'nullable',
             'entry_time_type' => 'nullable|required_with:entry_time_requirement', Rule::in(['<', '=', '>']),
+            'cto_time' => 'required|numeric|digits:4',
             'entry_time_requirement' => 'nullable|required_with:entry_time_type|digits:4|numeric',
             'datalink_authority' => 'required',
         ];

--- a/app/Models/ClxMessage.php
+++ b/app/Models/ClxMessage.php
@@ -76,6 +76,8 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @method static Builder|ClxMessage whereDatalinkAuthorityId($value)
  * @method static Builder|ClxMessage whereEntryTimeRestrictionIntervalCallsign($value)
  * @method static Builder|ClxMessage whereEntryTimeRestrictionIntervalMinutes($value)
+ * @property string|null $cto_time
+ * @method static Builder|ClxMessage whereCtoTime($value)
  * @mixin \Eloquent
  */
 class ClxMessage extends Model
@@ -99,7 +101,7 @@ class ClxMessage extends Model
      * @var array
      */
     protected $fillable = [
-        'vatsim_account_id', 'rcl_message_id', 'flight_level', 'mach', 'track_id', 'random_routeing', 'entry_fix', 'entry_time_restriction', 'free_text', 'datalink_authority_id', 'simple_datalink_message', 'datalink_message', 'upper_flight_level', 'raw_entry_time_restriction', 'overwritten_by_clx_message_id', 'overwritten', 'is_concorde', 'cancelled', 'cancellation_reason'
+        'vatsim_account_id', 'rcl_message_id', 'flight_level', 'mach', 'track_id', 'random_routeing', 'entry_fix', 'cto_time', 'entry_time_restriction', 'free_text', 'datalink_authority_id', 'simple_datalink_message', 'datalink_message', 'upper_flight_level', 'raw_entry_time_restriction', 'overwritten_by_clx_message_id', 'overwritten', 'is_concorde', 'cancelled', 'cancellation_reason'
     ];
 
     /**

--- a/database/factories/RclMessageFactory.php
+++ b/database/factories/RclMessageFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\DatalinkAuthority;
 use App\Models\RclMessage;
 use App\Models\Track;
 use App\Models\VatsimAccount;
@@ -31,6 +32,8 @@ class RclMessageFactory extends Factory
             'max_flight_level' => '410',
             'vatsim_account_id' => VatsimAccount::first()->id,
             'atc_rejected' => false,
+            'datalink_authority_id' => DatalinkAuthority::first()->id,
+            'target_datalink_authority_id' => DatalinkAuthority::first()->id,
         ];
     }
 

--- a/database/migrations/2025_02_22_052824_add_cto_to_clx_messages.php
+++ b/database/migrations/2025_02_22_052824_add_cto_to_clx_messages.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('clx_messages', function (Blueprint $table) {
+            $table->string('cto_time')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('clx_messages', function (Blueprint $table) {
+            $table->dropColumn('cto_time');
+        });
+    }
+};

--- a/resources/views/controllers/clx/rcl-messages/show.blade.php
+++ b/resources/views/controllers/clx/rcl-messages/show.blade.php
@@ -289,10 +289,6 @@
             Livewire.dispatch('levelChanged', { newLevel: this.value });
         });
 
-        // $('#entry_time_requirement').blur(function () {
-        //     Livewire.dispatch('timeChanged', { newTime: this.value });
-        // });
-
         $('#new_track_id').change(function () {
             Livewire.dispatch('trackChanged', { newTrackId: this.value });
         });

--- a/resources/views/controllers/clx/rcl-messages/show.blade.php
+++ b/resources/views/controllers/clx/rcl-messages/show.blade.php
@@ -9,7 +9,7 @@
                     Pending
                 </a>
             </p>
-            <p class="mb-4">x
+            <p class="mb-4">
                 <a class="icon-link icon-link-hover" href="{{ route('controllers.clx.pending') }}">
                     <i class="fa-solid fa-chevron-left"></i>
                     Processed

--- a/resources/views/controllers/clx/rcl-messages/show.blade.php
+++ b/resources/views/controllers/clx/rcl-messages/show.blade.php
@@ -9,7 +9,7 @@
                     Pending
                 </a>
             </p>
-            <p class="mb-4">
+            <p class="mb-4">x
                 <a class="icon-link icon-link-hover" href="{{ route('controllers.clx.pending') }}">
                     <i class="fa-solid fa-chevron-left"></i>
                     Processed
@@ -195,10 +195,18 @@
                                 @endif
                                 <hr class="my-3">
                                 <div class="col">
-                                    <label class="form-label" for="">Entry time requirement for {{ $message->entry_fix }}</label>
+                                    <label for="" class="form-label">Entry CTO for {{ $message->entry_fix }}</label>
+                                    <div class="input-group">
+                                        <input required type="number" class="form-control" value="{{ $message->entry_time }}" name="cto_time" id="cto_time" placeholder="e.g. 1350">
+                                    </div>
+                                </div>
+                                <hr class="my-3">
+                                <div class="col">
+                                    <label class="form-label" for="">Entry restriction for {{ $message->entry_fix }}</label>
                                     <div class="input-group">
                                         <select class="form-select form-select-sm" autocomplete="off" name="entry_time_type" id="entry_time_type">
-                                            <option value="=" selected>At</option>
+                                            <option value="none" selected>None</option>
+                                            <option value="=">At</option>
                                             <option value="<">Before</option>
                                             <option value=">">After</option>
                                         </select>
@@ -281,9 +289,9 @@
             Livewire.dispatch('levelChanged', { newLevel: this.value });
         });
 
-        $('#entry_time_requirement').blur(function () {
-            Livewire.dispatch('timeChanged', { newTime: this.value });
-        });
+        // $('#entry_time_requirement').blur(function () {
+        //     Livewire.dispatch('timeChanged', { newTime: this.value });
+        // });
 
         $('#new_track_id').change(function () {
             Livewire.dispatch('trackChanged', { newTrackId: this.value });
@@ -291,6 +299,10 @@
 
         $('#new_random_routeing').blur(function () {
             Livewire.dispatch('rrChanged', { newRouteing: this.value });
+        });
+
+        $('#cto_time').blur(function () {
+            Livewire.dispatch('timeChanged', { newTime: this.value });
         });
     </script>
 @endsection


### PR DESCRIPTION
Aims to resolve issue #95.

API output now is:
`"entry": {
      "fix": "JOOPY",
      "cto": "0537",
      "estimate": "0537",
      "restriction": "<0600"
    },
`

This is for a pilot who aimed for 0537, ATC confirmed their 'CTO' (no idea what it stands for but its the language used) as the same time, but with a restriction of before 6.

Without any restriction:

`entry": {
      "fix": "JOOPY",
      "cto": "0537",
      "estimate": "0537",
      "restriction": null
    },`