### PR TITLE
Change TMI initialization from 0 to null

### DIFF
--- a/app/Services/TracksService.php
+++ b/app/Services/TracksService.php
@@ -128,7 +128,7 @@ class TracksService
                 }
             }
 
-            $tmi = 0;
+            $tmi = null;
             foreach ($remarks as $remark) {
                 if (preg_match('/^TMI IS ([0-9]{3})/', $remark, $matches)) {
                     $tmi = (int) $matches[1];


### PR DESCRIPTION
attempt to get rid of the erroneous TMI 0 indications
setting tmi to null should allow for the regex below do his thing, and if it fails, for the carbon::now->dayofyear to actually do something, since there isn't already a 0 in the system 